### PR TITLE
Changed structure of chat protocol

### DIFF
--- a/src/GameServer.js
+++ b/src/GameServer.js
@@ -76,6 +76,7 @@ function GameServer() {
         tourneyEndTime: 30, // Amount of ticks to wait after a player wins (1 tick = 1000 ms)
         tourneyAutoFill: 0, // If set to a value higher than 0, the tournament match will automatically fill up with bots after this amount of seconds
         tourneyAutoFillPlayers: 1, // The timer for filling the server with bots will not count down unless there is this amount of real players
+        chatMaxMessageLength: 200, // Maximum message length
     };
     // Parse config
     this.loadConfig();

--- a/src/PacketHandler.js
+++ b/src/PacketHandler.js
@@ -81,8 +81,20 @@ PacketHandler.prototype.handleMessage = function(message) {
             this.socket.sendPacket(new Packet.SetBorder(c.borderLeft, c.borderRight, c.borderTop, c.borderBottom));
             break;
         case 99:
+            var message = "";
+            var maxLen = this.gameServer.config.chatMaxMessageLength * 2; // 2 bytes per char
+            var flags = view.getUint8(1); // for future use (e.g. broadcast vs local message)
+            for (var i = 2; i < view.byteLength && i <= maxLen; i += 2) {
+                var charCode = view.getUint16(i, true);
+                if (charCode == 0) {
+                    break;
+                }
+                message += String.fromCharCode(charCode);
+            }
+            var packet = new Packet.Chat(this.socket.playerTracker, message);
+            // Send to all clients (broadcast)
             for (var i = 0; i <this.gameServer.clients.length; i++) {
-                this.gameServer.clients[i].sendPacket(new Packet.Chat(buffer));
+                this.gameServer.clients[i].sendPacket(packet);
             }
             break;
         default:

--- a/src/PacketHandler.js
+++ b/src/PacketHandler.js
@@ -13,7 +13,7 @@ function PacketHandler(gameServer, socket) {
 
 module.exports = PacketHandler;
 
-PacketHandler.prototype.handleMessage = function(message) {
+PacketHandler.prototype.handleMessage = function (message) {
     function stobuf(buf) {
         var length = buf.length;
         var arrayBuf = new ArrayBuffer(length);
@@ -83,8 +83,18 @@ PacketHandler.prototype.handleMessage = function(message) {
         case 99:
             var message = "";
             var maxLen = this.gameServer.config.chatMaxMessageLength * 2; // 2 bytes per char
+            var offset = 2;
             var flags = view.getUint8(1); // for future use (e.g. broadcast vs local message)
-            for (var i = 2; i < view.byteLength && i <= maxLen; i += 2) {
+            if (flags & 2) {
+                offset += 4;
+            }
+            if (flags & 4) {
+                offset += 8;
+            }
+            if (flags & 8) {
+                offset += 16;
+            }
+            for (var i = offset; i < view.byteLength && i <= maxLen; i += 2) {
                 var charCode = view.getUint16(i, true);
                 if (charCode == 0) {
                     break;
@@ -93,7 +103,7 @@ PacketHandler.prototype.handleMessage = function(message) {
             }
             var packet = new Packet.Chat(this.socket.playerTracker, message);
             // Send to all clients (broadcast)
-            for (var i = 0; i <this.gameServer.clients.length; i++) {
+            for (var i = 0; i < this.gameServer.clients.length; i++) {
                 this.gameServer.clients[i].sendPacket(packet);
             }
             break;
@@ -102,14 +112,14 @@ PacketHandler.prototype.handleMessage = function(message) {
     }
 };
 
-PacketHandler.prototype.setNickname = function(newNick) {
+PacketHandler.prototype.setNickname = function (newNick) {
     var client = this.socket.playerTracker;
     if (client.cells.length < 1) {
         // Set name first
-        client.setName(newNick); 
+        client.setName(newNick);
 
         // If client has no cells... then spawn a player
-        this.gameServer.gameMode.onPlayerSpawn(this.gameServer,client);
+        this.gameServer.gameMode.onPlayerSpawn(this.gameServer, client);
 
         // Turn off spectate mode
         client.spectate = false;

--- a/src/packet/Chat.js
+++ b/src/packet/Chat.js
@@ -1,10 +1,46 @@
-function Chat(buf) {
-    this.buf = buf;
+function Chat(sender, message) {
+    this.sender = sender;
+    this.message = message;
 }
 
 module.exports = Chat;
 
-Chat.prototype.build = function() {
-    return this.buf;
+Chat.prototype.build = function () {
+    var buf = new ArrayBuffer(5);
+    var view = new DataView(buf);
+    var color = {'r': 153, 'g': 153, 'b': 153};
+    if (this.sender.cells.length > 0) {
+        color = this.sender.cells[0].getColor();
+    }
+    var nick = this.sender.getName();
+    if (!nick) {
+        if (this.sender.cells.length > 0) {
+            nick = 'An unnamed cell'
+        } else {
+            nick = 'Spectator'
+        }
+    }
+    view.setUint8(0, 99);
+    view.setUint8(1, 0); // flags for client; for future use
+    // Send color
+    view.setUint8(2, color.r);
+    view.setUint8(3, color.g);
+    view.setUint8(4, color.b);
+    var offset = 5;
+    // Send name
+    for (var j = 0; j < nick.length; j++) {
+        view.setUint16(offset, nick.charCodeAt(j), true);
+        offset += 2;
+    }
+    view.setUint16(offset, 0, true);
+    offset += 2;
+    // send message
+    for (var j = 0; j < this.message.length; j++) {
+        view.setUint16(offset, this.message.charCodeAt(j), true);
+        offset += 2;
+    }
+    view.setUint16(offset, 0, true);
+    offset += 2;
+    return buf;
 };
 

--- a/src/packet/UpdateLeaderboard.js
+++ b/src/packet/UpdateLeaderboard.js
@@ -31,7 +31,12 @@ UpdateLeaderboard.prototype.build = function() {
             var view = new DataView(buf);
 
             // Set packet data
-            view.setUint8(0, 49, true); // Packet ID
+            // TODO: check client version
+            //if(client = 1332175218){
+            view.setUint8(0, this.packetLB, true); // Packet ID
+            //}else{
+            //  view.setUin8(0, 49, true); // Packet ID
+            //}
             view.setUint32(1, validElements, true); // Number of elements
             var offset = 5;
 


### PR DESCRIPTION
A few improvements compared to the previous implementation:
- Changed the structure to be more in line with packages from the vanilla protocol.
- Clients can only send a message, they can't pick color or name. This way, a user cannot easily impersonate other users.
- Added flags. These can be used later to differentiate between different types of messages. A regular broadcast has no flags set. One of the bits could for example be used to indicate messages only sent to users within a certain range.
- Chat messages are limited in length. In the previous implementation, it was possible to send messages of arbitrary length.

An added benefit of the flags is, that we can use a single chat package for different kinds of messages. Other package ids remain free for features unrelated to messaging.

This is related to https://github.com/Eureka22/agar-clone/pull/10
